### PR TITLE
Add pip check to test suite

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 91c597a5067086eefd6f047c065f732ae04556629f4eff5501be9d7b805c17a5
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - blas
 
@@ -32,8 +32,10 @@ requirements:
 
 test:
   commands:
+    - pip check
     - pytest -v --pyargs mkl_random
   requires:
+    - pip
     - pytest  # [python_impl != "pypy"]
     - pytest <8  # [python_impl == "pypy"]
     - mkl-service


### PR DESCRIPTION
Add `pip check` to the recipe test commands to catch undeclared or broken PyPI runtime dependencies at build time.

Motivated by a recent issue where `mkl-service 2.7.1` introduced `dependencies = ["mkl"]` in `pyproject.toml`, which breaks `pip check` in downstream conda environments since `mkl` ships no `.dist-info` on conda-forge. Adding this check here ensures similar regressions are caught in-recipe in the future.

See: IntelPython/mkl-service#201